### PR TITLE
remove: nyxt-deb

### DIFF
--- a/packages/nyxt-deb/nyxt-deb.pacscript
+++ b/packages/nyxt-deb/nyxt-deb.pacscript
@@ -1,9 +1,0 @@
-name="nyxt-deb"
-version="2.2.4"
-gives="nyxt"
-repology=("project: nyxt" "repo: void_x86_64")
-url="https://github.com/atlas-engineer/nyxt/releases/download/${version}/nyxt_${version}_amd64.deb"
-description="Nyxt - the Internet on your terms."
-hash="ebbeb6734c97e6ab28e688c39d33ec2cd408a819163c23f73868d928a16f7e30"
-arch=('amd64')
-maintainer="cat-master21 <96554164+cat-master21@users.noreply.github.com>"


### PR DESCRIPTION
The deb version of nyxt was removed in favor of a self contained package with the [`3.0.0` version](https://github.com/atlas-engineer/nyxt/releases/tag/3.0.0)